### PR TITLE
Include SPI.h from MCP492X.h

### DIFF
--- a/MCP492X.h
+++ b/MCP492X.h
@@ -23,6 +23,7 @@
  */
 
 #include <Arduino.h>
+#include <SPI.h>
 
 // Ensure we don't double-define the functionality
 #ifndef MCP492X_h


### PR DESCRIPTION
Hi, since I had to patch this a few times in local clones of your otherwise perfectly usable library, and the solution is long known, I thought about just sending you a pull request.

Fixes #1 